### PR TITLE
Support running subset of RSpec example by name on Rake task

### DIFF
--- a/README.mkd
+++ b/README.mkd
@@ -36,3 +36,9 @@ This bot posts the image url related with user's post.
 ```bash
 bundle exec rake spec_with_env
 ```
+
+You can run only subset of RSpec example:
+
+```bash
+bundle exec rake 'spec_with_env["pixiv manga"]'
+```

--- a/Rakefile
+++ b/Rakefile
@@ -2,13 +2,15 @@ require 'rspec/core/rake_task'
 require 'yaml'
 
 desc 'DO NOT USE DIRECTLY, the reality of RSpec'
-RSpec::Core::RakeTask.new(:spec_run)
+RSpec::Core::RakeTask.new(:spec_run, :example_name) do |t, args|
+  t.rspec_opts = "-e #{args[:example_name]}" if args.has_key? :example_name
+end
 
 desc 'Run RSpec test with checking env bot needs'
-task :spec do |t|
+task :spec, :example_name do |t, args|
   envs = ['TWITTER_BEARER_TOKEN', 'DEVIANTART_ID', 'DEVIANTART_SECRET']
   if envs.reject(&ENV.method(:include?)).size == 0
-    Rake::Task[:spec_run].invoke
+    Rake::Task[:spec_run].invoke args[:example_name]
   else
     puts "Read README.mkd for setting env bot needs: #{envs.join(', ')}"
     puts "You can use default setting; bundle exec rake spec_with_env"
@@ -16,13 +18,13 @@ task :spec do |t|
 end
 
 desc 'Run RSpec test with using env what is in .travis.yml'
-task :spec_with_env do |t|
+task :spec_with_env, :example_name do |t, args|
   yaml = YAML.load_file('.travis.yml')
   yaml['env']['global'].each do |e|
     key, value = e.split(?=)
     ENV[key] = value.gsub(/^'(.+)'$/, '\1')
   end
-  Rake::Task[:spec_run].invoke
+  Rake::Task[:spec_run].invoke args[:example_name]
 end
 
 task :default => :spec

--- a/Rakefile
+++ b/Rakefile
@@ -1,7 +1,7 @@
 require 'rspec/core/rake_task'
 require 'yaml'
 
-desc 'The reality of RSpec'
+desc 'DO NOT USE DIRECTLY, the reality of RSpec'
 RSpec::Core::RakeTask.new(:spec_run)
 
 desc 'Run RSpec test with checking env bot needs'


### PR DESCRIPTION
You can run only subset of RSpec example:

```bash
bundle exec rake 'spec_with_env["pixiv manga"]'
```